### PR TITLE
feat: add --use-collection-folder flag for nested folder structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to the Postman to Insomnia CLI converter will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2025-07-09
+
+### Added
+- **Collection Folder Structure Option** - New `--use-collection-folder` flag to add collection name as containing folder
+  - Creates nested structure: `Collection Name > Collection Name > Folders/Requests`
+  - Matches Insomnia UI conversion behavior more closely
+  - Optional flag with backward compatibility (defaults to `false`)
+  - Will become default behavior in future version for UI consistency
+
+### Enhanced
+- **Flexible Folder Organization** - Users can now choose between:
+  - Original structure (default): `Collection Name > Folders/Requests`
+  - Nested structure (new): `Collection Name > Collection Name > Folders/Requests`
+- **Type Safety** - Updated `Converter` interface to support new optional parameter
+- **CLI Documentation** - Added help text and examples for new folder structure option
+
+### Technical Details
+- Extended `ImportPostman` class with optional `addCollectionFolder` parameter
+- Updated conversion pipeline to support both folder structure modes
+- Maintained full backward compatibility with existing conversions
+- Added comprehensive unit tests for both structure modes
+
+### Usage Examples
+```bash
+# Default behavior (original structure)
+postman2insomnia collection.json
+
+# New nested structure (matches Insomnia UI)
+postman2insomnia collection.json --use-collection-folder
+
+# Combined with other options
+postman2insomnia collection.json --use-collection-folder --preprocess --postprocess
+```
+
+**Note**: The default behavior remains unchanged for backward compatibility. In a future major version, `--use-collection-folder` will become the default to better match Insomnia UI behavior.
+
 ## [1.3.0] - 2025-07-09
 
 - **Fix ordering issue** - corrected how the CLI generates the keys for sorting requests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Postman to Insomnia CLI Converter
 
-A powerful command-line tool that converts Postman collections and environments to Insomnia v5 YAML format with advanced script compatibility features. This tool was built by extracting and adapting the core conversion logic from Insomnia's UI codebase to create a standalone CLI utility.
+A powerful command-line tool that converts Postman collections and environments to Insomnia v5 YAML format with advanced script compatibility features and flexible folder organization. This tool was built by extracting and adapting the core conversion logic from Insomnia's UI codebase to create a standalone CLI utility.
 
 ## 🚀 Features
 
@@ -15,7 +15,15 @@ A powerful command-line tool that converts Postman collections and environments 
 - **Filters disabled variables** from environments
 - **Auto-detects file types** (collection vs environment)
 
-### 🔧 Transform System (New!)
+### 📁 Folder Structure Options (New!)
+- **Flexible folder organization** - Choose between two folder structures:
+  - **Original structure** (default): `Collection Name > Folders/Requests`
+  - **Nested structure**: `Collection Name > Collection Name > Folders/Requests`
+- **Insomnia UI compatibility** - Nested structure matches how Insomnia UI performs conversions
+- **Backward compatibility** - Default behavior preserved for existing workflows
+- **Future-ready** - Nested structure will become default in future major version
+
+### 🔧 Transform System
 - **Preprocessing transforms** - Fix deprecated Postman syntax before conversion
 - **Postprocessing transforms** - Fix Insomnia API differences after conversion
 - **Script compatibility engine** - Automatically resolves API differences between Postman and Insomnia
@@ -91,6 +99,26 @@ postman2insomnia collection.json -o ./converted-files
 postman2insomnia collection.json -v
 ```
 
+### 📁 Folder Structure Options
+
+```bash
+# Default structure: Collection Name > Folders/Requests
+postman2insomnia collection.json
+
+# Nested structure (matches Insomnia UI): Collection Name > Collection Name > Folders/Requests
+postman2insomnia collection.json --use-collection-folder
+
+# Example result with --use-collection-folder:
+# Consumer Finance (collection)
+# ├── Consumer Finance (root folder)
+# │   ├── Document (subfolder)
+# │   │   ├── Step 1. Get Access token
+# │   │   └── Step 2. Validate token
+# │   └── Token (subfolder)
+# │       ├── Kong - Generate token
+# │       └── Kong - PSD2
+```
+
 ### 🆕 Transform Usage
 
 ```bash
@@ -113,14 +141,17 @@ postman2insomnia --generate-config ./sample-config.json
 ### Advanced Options
 
 ```bash
-# Merge multiple collections with transforms
-postman2insomnia col1.json col2.json env.json -m --preprocess --postprocess
+# Nested structure with transforms
+postman2insomnia collection.json --use-collection-folder --preprocess --postprocess
 
-# Batch convert with custom transforms and verbose output
-postman2insomnia exports/*.json --preprocess --postprocess -o ./output -v
+# Merge multiple collections with nested structure
+postman2insomnia col1.json col2.json env.json -m --use-collection-folder
 
-# Use custom config for enterprise collections
-postman2insomnia enterprise/*.json --config-file ./enterprise-transforms.json -o ./converted
+# Batch convert with nested structure and custom transforms
+postman2insomnia exports/*.json --use-collection-folder --preprocess --postprocess -o ./output -v
+
+# Use custom config for enterprise collections with nested structure
+postman2insomnia enterprise/*.json --use-collection-folder --config-file ./enterprise-transforms.json -o ./converted
 ```
 
 ### Transform Configuration Management
@@ -143,6 +174,7 @@ postman2insomnia collection.json --config-file ./transforms.json
 | `--output <dir>` | `-o` | Output directory | `./output` |
 | `--merge` | `-m` | Merge all collections into a single file | `false` |
 | `--verbose` | `-v` | Verbose output | `false` |
+| `--use-collection-folder` | | Add collection name as containing folder | `false`* |
 | `--preprocess` | | Apply preprocessing transforms | `false` |
 | `--postprocess` | | Apply postprocessing transforms | `false` |
 | `--config-file <path>` | | Custom transform configuration file | |
@@ -150,7 +182,15 @@ postman2insomnia collection.json --config-file ./transforms.json
 | `--help` | `-h` | Show help | |
 | `--version` | `-V` | Show version | |
 
-## 🔍 When to Use Transforms
+*_**Note**: `--use-collection-folder` currently defaults to `false` for backward compatibility. In a future major version, this will become the default behavior to better match how Insomnia UI performs conversions._
+
+## 🔍 When to Use Options
+
+### Use `--use-collection-folder` when:
+- You want the converted structure to match Insomnia UI behavior
+- You prefer nested folder organization: `Collection > Collection > Items`
+- You're migrating from Insomnia UI imports to CLI workflow
+- You want better organization for complex collections
 
 ### Use `--preprocess` when:
 - Converting old Postman collections with deprecated syntax
@@ -164,9 +204,14 @@ postman2insomnia collection.json --config-file ./transforms.json
 - Header comparisons don't work as expected
 - Request manipulation methods fail
 
-### Use both (recommended):
+### Use both transforms (recommended):
 ```bash
 postman2insomnia collection.json --preprocess --postprocess
+```
+
+### Use nested structure with transforms (recommended for new projects):
+```bash
+postman2insomnia collection.json --use-collection-folder --preprocess --postprocess
 ```
 
 ## File Types Supported
@@ -184,13 +229,24 @@ postman2insomnia collection.json --preprocess --postprocess
 
 ## 📋 Examples
 
-### Convert a Collection with Script Fixes
+### Convert with Nested Structure (Recommended)
 
 ```bash
-# Input: my-api.json (Postman collection with scripts)
+# Input: my-api.json (Postman collection)
+postman2insomnia my-api.json --use-collection-folder --preprocess --postprocess
+
+# Output: ./output/my-api.insomnia.yaml (with nested structure and working scripts)
+# Structure: My API > My API > Folders/Requests
+```
+
+### Convert with Original Structure
+
+```bash
+# Input: my-api.json (Postman collection)
 postman2insomnia my-api.json --preprocess --postprocess
 
-# Output: ./output/my-api.insomnia.yaml (with working scripts)
+# Output: ./output/my-api.insomnia.yaml (with original structure and working scripts)
+# Structure: My API > Folders/Requests
 ```
 
 ### Convert Environments
@@ -204,17 +260,19 @@ postman2insomnia dev-env.json prod-env.json -o ./envs
 # ./envs/prod-env.insomnia.yaml
 ```
 
-### Batch Conversion with Custom Transforms
+### Batch Conversion with Nested Structure
 
 ```bash
-# Convert all exports with custom transform rules
+# Convert all exports with nested structure and custom transforms
 postman2insomnia postman-exports/*.json \
+  --use-collection-folder \
   --config-file ./my-transforms.json \
   -o ./converted \
   -v
 
-# Merge into single file with transforms
+# Merge into single file with nested structure
 postman2insomnia postman-exports/*.json \
+  --use-collection-folder \
   --preprocess --postprocess \
   --merge \
   -o ./merged
@@ -232,12 +290,40 @@ postman2insomnia config --generate ./company-transforms.json
 # 3. Validate configuration
 postman2insomnia config --validate ./company-transforms.json
 
-# 4. Convert with custom rules
+# 4. Convert with custom rules and nested structure
 postman2insomnia collections/*.json \
+  --use-collection-folder \
   --config-file ./company-transforms.json \
   -o ./insomnia-imports \
   --verbose
 ```
+
+## 🏗️ Folder Structure Comparison
+
+### Original Structure (Current Default)
+```
+Consumer Finance (collection)
+├── Document (subfolder)
+│   ├── Step 1. Get Access token
+│   └── Step 2. Validate token
+└── Token (subfolder)
+    ├── Kong - Generate token
+    └── Kong - PSD2
+```
+
+### Nested Structure (--use-collection-folder)
+```
+Consumer Finance (collection)
+├── Consumer Finance (root folder)
+│   ├── Document (subfolder)
+│   │   ├── Step 1. Get Access token
+│   │   └── Step 2. Validate token
+│   └── Token (subfolder)
+│       ├── Kong - Generate token
+│       └── Kong - PSD2
+```
+
+The nested structure matches how Insomnia UI performs conversions and provides better organization for complex collections.
 
 ## 🐛 Common Issues & Solutions
 
@@ -279,6 +365,22 @@ postman2insomnia collection.json --preprocess
 // ✅ Updated to modern syntax
 var token = pm.environment.get('auth_token');
 pm.test('Status is 200', function() { pm.expect(pm.response.code).to.equal(200); });
+```
+
+### Folder Structure Preferences
+
+**Problem**: Converted structure doesn't match Insomnia UI imports
+```
+// CLI default structure
+Collection Name > Folders/Requests
+
+// Insomnia UI structure  
+Collection Name > Collection Name > Folders/Requests
+```
+
+**Solution**: Use `--use-collection-folder` flag
+```bash
+postman2insomnia collection.json --use-collection-folder
 ```
 
 ## 📖 Advanced Transform Configuration
@@ -342,6 +444,7 @@ jobs:
       - name: Convert collections
         run: |
           postman2insomnia postman-exports/*.json \
+            --use-collection-folder \
             --preprocess --postprocess \
             --output ./insomnia-collections \
             --verbose
@@ -369,7 +472,9 @@ This CLI tool was built by extracting and adapting the core conversion logic fro
 
 4. **Enhanced with Transform System** to solve script compatibility issues
 
-5. **Maintained compatibility** with original Insomnia conversion logic
+5. **Added flexible folder structure options** to match different workflow preferences
+
+6. **Maintained compatibility** with original Insomnia conversion logic
 
 ## 🔧 Technical Details
 
@@ -401,6 +506,12 @@ This CLI tool was built by extracting and adapting the core conversion logic fro
 3. **v5 Format Only**: Outputs Insomnia v5 format (not v4 or older)
 4. **Node.js Required**: Requires Node.js runtime (not a standalone binary)
 5. **YAML Output**: Primarily generates YAML (JSON option exists but not fully implemented)
+
+## 🔮 Future Changes
+
+**Important**: In a future major version (v2.0.0), the `--use-collection-folder` behavior will become the default to better match how Insomnia UI performs conversions. This will be a breaking change, but the current behavior will remain available via a flag.
+
+**Migration Path**: Start using `--use-collection-folder` now to prepare for the future default behavior.
 
 ## 🤝 Contributing
 
@@ -439,5 +550,3 @@ This project adapts open-source code from the Insomnia project. Please refer to 
 ---
 
 **Built with ❤️ by adapting the excellent work of the Insomnia team**
-
-**Transform System**: Solving script compatibility issues so your converted collections just work! ✨

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,6 +58,9 @@ interface CliOptions {
 
   /** Generate a sample transform configuration file */
   generateConfig?: string;
+
+  /** Add collection name as containing folder for all items */
+  useCollectionFolder?: boolean;
 }
 
 // =============================================================================
@@ -87,6 +90,9 @@ program
   .option('--postprocess', 'Apply postprocessing transforms to fix Insomnia API differences', false)
   .option('--config-file <path>', 'Path to custom transform configuration file')
   .option('--generate-config <path>', 'Generate a sample transform configuration file and exit')
+
+  // Might be needed for accurate conversions: Add the collection folder option
+  .option('--use-collection-folder', 'Add collection name as containing folder for all items', false)
 
   // Main action handler - this is where the actual work happens
   .action(async (inputs: string[], options: CliOptions) => {
@@ -149,7 +155,8 @@ program
         verbose: options.verbose,
         preprocess: options.preprocess,
         postprocess: options.postprocess,
-        configFile: options.configFile
+        configFile: options.configFile,
+        useCollectionFolder: options.useCollectionFolder
       });
 
       // =======================================================================

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -47,6 +47,7 @@ export interface ConversionOptions {
   postprocess?: boolean;
   configFile?: string;
   transformEngine?: TransformEngine;
+  useCollectionFolder?: boolean;
 }
 
 export interface ConversionResult {
@@ -247,7 +248,7 @@ function convertPostmanCollectionWithTransforms(
     const collection = JSON.parse(rawData);
 
     // Use the existing converter logic but with enhanced script processing
-    const result = postmanConvert(rawData, transformEngine);
+    const result = postmanConvert(rawData, transformEngine, options?.useCollectionFolder);
 
     // The result from postmanConvert might be ConvertResult, but we need any[] | null
     // So we need to check if it's an array and handle other cases

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -303,9 +303,15 @@ type ConvertResult = ImportRequest[] | ConvertErrorResult | null;
  * All format-specific converters (Postman, environments, etc.) implement this interface
  *
  * @param rawData Raw string content from the input file
+ * @param transformEngine Optional transform engine for preprocessing/postprocessing
+ * @param useCollectionFolder Optional flag to add collection name as containing folder
  * @returns Conversion result or error
  */
-export type Converter = (rawData: string, transformEngine?: any) => ConvertResult | Promise<ConvertResult>;
+export type Converter = (
+  rawData: string,
+  transformEngine?: any,
+  useCollectionFolder?: boolean
+) => ConvertResult | Promise<ConvertResult>;
 
 /**
  * Import entry metadata

--- a/tests/unit/use-collection-folder.test.ts
+++ b/tests/unit/use-collection-folder.test.ts
@@ -1,0 +1,464 @@
+// =============================================================================
+// UNIT TESTS FOR --use-collection-folder FEATURE
+// =============================================================================
+import { convert } from '../../src/postman-converter';
+import type { ImportRequest } from '../../src/types/entities';
+
+describe('--use-collection-folder Feature', () => {
+  // ==========================================================================
+  // TEST DATA FIXTURES
+  // ==========================================================================
+
+  const createTestCollection = (name = 'Consumer Finance') => ({
+    info: {
+      name,
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      _postman_id: 'test-collection-id',
+      description: 'Test collection for folder structure testing'
+    },
+    item: [
+      {
+        name: 'Document',
+        item: [
+          {
+            name: 'Step 1. Get Access token',
+            request: {
+              method: 'POST',
+              url: 'https://example.com/auth/token',
+              header: [
+                { key: 'Content-Type', value: 'application/x-www-form-urlencoded' }
+              ],
+              body: {
+                mode: 'urlencoded',
+                urlencoded: [
+                  { key: 'grant_type', value: 'client_credentials' }
+                ]
+              }
+            }
+          },
+          {
+            name: 'Step 2. Validate token',
+            request: {
+              method: 'POST',
+              url: 'https://example.com/auth/validate'
+            }
+          }
+        ]
+      },
+      {
+        name: 'Token',
+        item: [
+          {
+            name: 'Kong - Generate token',
+            request: {
+              method: 'POST',
+              url: 'https://example.com/kong/token'
+            }
+          },
+          {
+            name: 'Kong - PSD2',
+            request: {
+              method: 'GET',
+              url: 'https://example.com/psd2/accounts'
+            }
+          }
+        ]
+      }
+    ]
+  });
+
+  const createSimpleCollection = (name = 'Simple API') => ({
+    info: {
+      name,
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+    },
+    item: [
+      {
+        name: 'Get Users',
+        request: {
+          method: 'GET',
+          url: 'https://api.example.com/users'
+        }
+      },
+      {
+        name: 'Create User',
+        request: {
+          method: 'POST',
+          url: 'https://api.example.com/users'
+        }
+      }
+    ]
+  });
+
+  // ==========================================================================
+  // HELPER FUNCTIONS
+  // ==========================================================================
+
+  const findItemByName = (items: ImportRequest[], name: string): ImportRequest | undefined => {
+    return items.find(item => item.name === name);
+  };
+
+  const findItemsByParentId = (items: ImportRequest[], parentId: string): ImportRequest[] => {
+    return items.filter(item => item.parentId === parentId);
+  };
+
+  const findRootFolder = (items: ImportRequest[]): ImportRequest | undefined => {
+    return items.find(item =>
+      item._type === 'request_group' &&
+      item.parentId === '__WORKSPACE_ID__'
+    );
+  };
+
+  // ==========================================================================
+  // DEFAULT BEHAVIOR TESTS (useCollectionFolder = false)
+  // ==========================================================================
+
+  describe('Default Behavior (useCollectionFolder = false)', () => {
+    test('should create original structure without nested collection folder', () => {
+      const collection = createTestCollection();
+      const result = convert(JSON.stringify(collection), undefined, false) as ImportRequest[];
+
+      expect(result).toBeTruthy();
+      expect(Array.isArray(result)).toBe(true);
+
+      // Should have: root folder + 2 subfolders + 4 requests = 7 items
+      expect(result).toHaveLength(7);
+
+      // Find root collection folder
+      const rootFolder = findRootFolder(result);
+      expect(rootFolder).toBeTruthy();
+      expect(rootFolder!.name).toBe('Consumer Finance');
+
+      // Document and Token should be direct children of root folder
+      const documentFolder = findItemByName(result, 'Document');
+      const tokenFolder = findItemByName(result, 'Token');
+
+      expect(documentFolder).toBeTruthy();
+      expect(tokenFolder).toBeTruthy();
+      expect(documentFolder!.parentId).toBe(rootFolder!._id);
+      expect(tokenFolder!.parentId).toBe(rootFolder!._id);
+
+      // Verify requests are children of their respective folders
+      const documentRequests = findItemsByParentId(result, documentFolder!._id!);
+      const tokenRequests = findItemsByParentId(result, tokenFolder!._id!);
+
+      expect(documentRequests).toHaveLength(2);
+      expect(tokenRequests).toHaveLength(2);
+    });
+
+    test('should handle simple collection with direct requests', () => {
+      const collection = createSimpleCollection();
+      const result = convert(JSON.stringify(collection), undefined, false) as ImportRequest[];
+
+      expect(result).toBeTruthy();
+      expect(result).toHaveLength(3); // root folder + 2 requests
+
+      const rootFolder = findRootFolder(result);
+      expect(rootFolder!.name).toBe('Simple API');
+
+      const requests = findItemsByParentId(result, rootFolder!._id!);
+      expect(requests).toHaveLength(2);
+      expect(requests[0]._type).toBe('request');
+      expect(requests[1]._type).toBe('request');
+    });
+
+    test('should default to false when useCollectionFolder is undefined', () => {
+      const collection = createTestCollection();
+      const result = convert(JSON.stringify(collection)) as ImportRequest[];
+
+      // Should behave same as explicit false
+      const rootFolder = findRootFolder(result);
+      const documentFolder = findItemByName(result, 'Document');
+
+      expect(documentFolder!.parentId).toBe(rootFolder!._id);
+    });
+  });
+
+  // ==========================================================================
+  // NEW BEHAVIOR TESTS (useCollectionFolder = true)
+  // ==========================================================================
+
+  describe('New Behavior (useCollectionFolder = true)', () => {
+    test('should create nested collection folder structure', () => {
+      const collection = createTestCollection();
+      const result = convert(JSON.stringify(collection), undefined, true) as ImportRequest[];
+
+      expect(result).toBeTruthy();
+      expect(Array.isArray(result)).toBe(true);
+
+      // Should have: root folder + intermediate folder + 2 subfolders + 4 requests = 8 items
+      expect(result).toHaveLength(8);
+
+      // Find root collection folder
+      const rootFolder = findRootFolder(result);
+      expect(rootFolder).toBeTruthy();
+      expect(rootFolder!.name).toBe('Consumer Finance');
+
+      // Find intermediate collection folder (child of root)
+      const intermediateFolder = findItemsByParentId(result, rootFolder!._id!)[0];
+      expect(intermediateFolder).toBeTruthy();
+      expect(intermediateFolder._type).toBe('request_group');
+      expect(intermediateFolder.name).toBe('Consumer Finance'); // Same name as collection
+
+      // Document and Token should be children of intermediate folder
+      const documentFolder = findItemByName(result, 'Document');
+      const tokenFolder = findItemByName(result, 'Token');
+
+      expect(documentFolder).toBeTruthy();
+      expect(tokenFolder).toBeTruthy();
+      expect(documentFolder!.parentId).toBe(intermediateFolder._id);
+      expect(tokenFolder!.parentId).toBe(intermediateFolder._id);
+
+      // Verify requests are still children of their respective folders
+      const documentRequests = findItemsByParentId(result, documentFolder!._id!);
+      const tokenRequests = findItemsByParentId(result, tokenFolder!._id!);
+
+      expect(documentRequests).toHaveLength(2);
+      expect(tokenRequests).toHaveLength(2);
+    });
+
+    test('should handle simple collection with intermediate folder', () => {
+      const collection = createSimpleCollection();
+      const result = convert(JSON.stringify(collection), undefined, true) as ImportRequest[];
+
+      expect(result).toBeTruthy();
+      expect(result).toHaveLength(4); // root folder + intermediate folder + 2 requests
+
+      const rootFolder = findRootFolder(result);
+      expect(rootFolder!.name).toBe('Simple API');
+
+      // Find intermediate folder
+      const intermediateFolder = findItemsByParentId(result, rootFolder!._id!)[0];
+      expect(intermediateFolder.name).toBe('Simple API');
+      expect(intermediateFolder._type).toBe('request_group');
+
+      // Requests should be children of intermediate folder
+      const requests = findItemsByParentId(result, intermediateFolder._id!);
+      expect(requests).toHaveLength(2);
+      expect(requests[0]._type).toBe('request');
+      expect(requests[1]._type).toBe('request');
+    });
+
+    test('should preserve collection metadata in both folders', () => {
+      const collection = createTestCollection();
+      const result = convert(JSON.stringify(collection), undefined, true) as ImportRequest[];
+
+      const rootFolder = findRootFolder(result);
+      const intermediateFolder = findItemsByParentId(result, rootFolder!._id!)[0];
+
+      // Both folders should have the same name
+      expect(rootFolder!.name).toBe('Consumer Finance');
+      expect(intermediateFolder.name).toBe('Consumer Finance');
+
+      // Root folder should have collection metadata
+      expect(rootFolder!.description).toBe('Test collection for folder structure testing');
+
+      // Intermediate folder should have empty auth (not inherit from collection)
+      expect(intermediateFolder.authentication).toEqual({});
+    });
+  });
+
+  // ==========================================================================
+  // EDGE CASES AND ERROR HANDLING
+  // ==========================================================================
+
+  describe('Edge Cases', () => {
+    test('should handle empty collection with useCollectionFolder = true', () => {
+      const emptyCollection = {
+        info: {
+          name: 'Empty Collection',
+          schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+        },
+        item: []
+      };
+
+      const result = convert(JSON.stringify(emptyCollection), undefined, true) as ImportRequest[];
+
+      expect(result).toBeTruthy();
+      expect(result).toHaveLength(2); // root folder + intermediate folder
+
+      const rootFolder = findRootFolder(result);
+      const intermediateFolder = findItemsByParentId(result, rootFolder!._id!)[0];
+
+      expect(rootFolder!.name).toBe('Empty Collection');
+      expect(intermediateFolder.name).toBe('Empty Collection');
+    });
+
+    test('should handle collection with special characters in name', () => {
+      const collection = createTestCollection('Test & Special "Characters" Collection');
+      const result = convert(JSON.stringify(collection), undefined, true) as ImportRequest[];
+
+      const rootFolder = findRootFolder(result);
+      const intermediateFolder = findItemsByParentId(result, rootFolder!._id!)[0];
+
+      expect(rootFolder!.name).toBe('Test & Special "Characters" Collection');
+      expect(intermediateFolder.name).toBe('Test & Special "Characters" Collection');
+    });
+
+    test('should handle deeply nested folder structure', () => {
+      const deepCollection = {
+        info: {
+          name: 'Deep Collection',
+          schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+        },
+        item: [
+          {
+            name: 'Level 1',
+            item: [
+              {
+                name: 'Level 2',
+                item: [
+                  {
+                    name: 'Level 3',
+                    item: [
+                      {
+                        name: 'Deep Request',
+                        request: {
+                          method: 'GET',
+                          url: 'https://api.example.com/deep'
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+
+      const result = convert(JSON.stringify(deepCollection), undefined, true) as ImportRequest[];
+
+      // Should have: root + intermediate + 3 nested folders + 1 request = 6 items
+      expect(result).toHaveLength(6);
+
+      const rootFolder = findRootFolder(result);
+      const intermediateFolder = findItemsByParentId(result, rootFolder!._id!)[0];
+      const level1Folder = findItemsByParentId(result, intermediateFolder._id!)[0];
+
+      expect(level1Folder.name).toBe('Level 1');
+      expect(level1Folder.parentId).toBe(intermediateFolder._id);
+    });
+  });
+
+  // ==========================================================================
+  // COMPARISON TESTS
+  // ==========================================================================
+
+  describe('Behavior Comparison', () => {
+    test('should produce different structures for same collection', () => {
+      const collection = createTestCollection();
+
+      const defaultResult = convert(JSON.stringify(collection), undefined, false) as ImportRequest[];
+      const nestedResult = convert(JSON.stringify(collection), undefined, true) as ImportRequest[];
+
+      // Default should have fewer items (no intermediate folder)
+      expect(defaultResult).toHaveLength(7);
+      expect(nestedResult).toHaveLength(8);
+
+      // In default, Document folder is direct child of root
+      const defaultRoot = findRootFolder(defaultResult);
+      const defaultDocument = findItemByName(defaultResult, 'Document');
+      expect(defaultDocument!.parentId).toBe(defaultRoot!._id);
+
+      // In nested, Document folder is child of intermediate folder
+      const nestedRoot = findRootFolder(nestedResult);
+      const nestedIntermediate = findItemsByParentId(nestedResult, nestedRoot!._id!)[0];
+      const nestedDocument = findItemByName(nestedResult, 'Document');
+      expect(nestedDocument!.parentId).toBe(nestedIntermediate._id);
+    });
+
+    test('should maintain same request content regardless of folder structure', () => {
+      const collection = createTestCollection();
+
+      const defaultResult = convert(JSON.stringify(collection), undefined, false) as ImportRequest[];
+      const nestedResult = convert(JSON.stringify(collection), undefined, true) as ImportRequest[];
+
+      // Find the same request in both structures
+      const defaultRequest = defaultResult.find(item =>
+        item._type === 'request' && item.name === 'Step 1. Get Access token'
+      );
+      const nestedRequest = nestedResult.find(item =>
+        item._type === 'request' && item.name === 'Step 1. Get Access token'
+      );
+
+      expect(defaultRequest).toBeTruthy();
+      expect(nestedRequest).toBeTruthy();
+
+      // Request content should be identical
+      expect(defaultRequest!.method).toBe(nestedRequest!.method);
+      expect(defaultRequest!.url).toBe(nestedRequest!.url);
+      expect(defaultRequest!.name).toBe(nestedRequest!.name);
+    });
+  });
+
+  // ==========================================================================
+  // INTEGRATION WITH TRANSFORM ENGINE
+  // ==========================================================================
+
+  describe('Integration with Transform Engine', () => {
+    test('should work with transform engine when useCollectionFolder = true', () => {
+      const collection = createTestCollection();
+      const mockTransformEngine = {
+        preprocess: jest.fn((data) => data),
+        postprocess: jest.fn((data) => data)
+      };
+
+      const result = convert(JSON.stringify(collection), mockTransformEngine, true) as ImportRequest[];
+
+      expect(result).toBeTruthy();
+      expect(result).toHaveLength(8); // Structure should be correct
+
+      const rootFolder = findRootFolder(result);
+      const intermediateFolder = findItemsByParentId(result, rootFolder!._id!)[0];
+
+      expect(rootFolder!.name).toBe('Consumer Finance');
+      expect(intermediateFolder.name).toBe('Consumer Finance');
+    });
+
+    test('should work without transform engine when useCollectionFolder = true', () => {
+      const collection = createTestCollection();
+
+      const result = convert(JSON.stringify(collection), undefined, true) as ImportRequest[];
+
+      expect(result).toBeTruthy();
+      expect(result).toHaveLength(8);
+
+      const rootFolder = findRootFolder(result);
+      expect(rootFolder!.name).toBe('Consumer Finance');
+    });
+  });
+});
+
+// =============================================================================
+// MOCK IMPLEMENTATIONS (if needed for your test setup)
+// =============================================================================
+
+jest.mock('../../src/postman-converter', () => {
+  const originalModule = jest.requireActual('../../src/postman-converter');
+
+  return {
+    ...originalModule,
+    UUIDGenerator: jest.fn().mockImplementation(() => ({
+      generateGroupId: jest.fn(() => 'mock-group-id'),
+      generateRequestId: jest.fn(() => 'mock-request-id')
+    }))
+  };
+});
+
+/*
+WHAT THESE TESTS VERIFY:
+
+Default behavior (useCollectionFolder = false) works as before
+New behavior (useCollectionFolder = true) creates nested structure
+Edge cases are handled properly
+Both structures contain the same request content
+Integration with transform engine works
+Error handling and special characters work
+
+COVERAGE:
+- All code paths in the importCollection method
+- Both true and false values for useCollectionFolder
+- Edge cases like empty collections and special characters
+- Integration with existing transform engine functionality
+*/


### PR DESCRIPTION
- Add optional --use-collection-folder flag to create nested collection structure
- Creates structure: Collection Name > Collection Name > Folders/Requests
- Matches Insomnia UI conversion behaviour more closely
- Maintains backward compatibility (defaults to false)
- Will become default in future major version for UI consistency

Technical changes:
- Extended ImportPostman class with addCollectionFolder parameter
- Updated Converter type signature to support new optional parameter
- Added CLI option with full pipeline integration
- Unit tests for both structure modes

Examples:
- Default: postman2insomnia collection.json
- Nested: postman2insomnia collection.json --use-collection-folder

Resolves folder organisation inconsistency with Insomnia UI imports